### PR TITLE
グローバル CSS の side-effect import に型宣言を追加（TS6 先行対応）

### DIFF
--- a/my-slack-app/css.d.ts
+++ b/my-slack-app/css.d.ts
@@ -1,0 +1,5 @@
+// Global CSS side-effect imports (e.g. `import "./globals.css"`).
+// Next.js のビルトイン型は CSS Modules (*.module.css) のみを宣言しており、
+// プレーンな CSS の副作用 import には型宣言がないため、ここで補う。
+// (TypeScript 6.0 以降は side-effect import を既定で型チェックするため必要)
+declare module "*.css";


### PR DESCRIPTION
## 概要
- グローバル CSS の side-effect import に対する型宣言を追加し、`npx tsc --noEmit` 実行時に発生していた `TS2882: Cannot find module or type declarations for side-effect import of './globals.css'` を解消
- 原因は、TypeScript 6.0 以降は side-effect import も既定で型チェックされる一方、Next.js のビルトイン型（`next/types/global.d.ts`）は `*.module.css`（CSS Modules）のみ宣言しており、`src/app/layout.tsx` の `import "./globals.css"` のようなプレーンなグローバル CSS import に型宣言が存在しないため
- 対応として `my-slack-app/css.d.ts` を新規追加し `declare module "*.css";` を宣言。tsconfig の include（`**/*.ts`）により自動的に読み込まれる
- `next-env.d.ts` は自動生成ファイルのため編集していない

### 注意点
- 現状 develop の `package.json` は `typescript ^5` のままで、この `TS2882` は TS6 環境でのみ発生する
- 本 PR は TS6 アップグレードに対する先行修正であり、追加した `declare module` は TS5 でも無害

## テスト方法
- [ ] TS6 環境で `my-slack-app/` にて `npx tsc --noEmit` を実行し、`TS2882` が発生しないことを確認
- [ ] `npm run build` が成功することを確認
- [ ] TS5 環境でも `npx tsc --noEmit` / `npm run build` が問題なく通ることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)